### PR TITLE
Fixed an issue that occured in Revit 2025

### DIFF
--- a/lib/tools/finishing.py
+++ b/lib/tools/finishing.py
@@ -196,8 +196,7 @@ class FinishingRoom(object):
         # Input parameter values from rooms
         if rswitches['Consider Thickness'] == False \
                 and ceiling_type.FamilyName == 'Compound Ceiling':
-            offset2 = self.doc.GetElement(ceiling_type)\
-                .get_Parameter(DB.BuiltInParameter.CEILING_THICKNESS).AsDouble()
+            offset2 = ceiling_type.get_Parameter(DB.BuiltInParameter.CEILING_THICKNESS).AsDouble()
             new_ceiling.get_Parameter(DB.BuiltInParameter.CEILING_HEIGHTABOVELEVEL_PARAM)\
                 .Set(room_offset2 + offset2)
         else:


### PR DESCRIPTION
The error was occurring because the code was trying to call GetElement() on a ceiling_type object that was already an element. I've fixed this by removing the unnecessary call to self.doc.GetElement(ceiling_type) and instead directly accessing the parameter from the ceiling_type object.